### PR TITLE
Add Slices for XCFramework in visionOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,10 +82,10 @@ iOS/testbed/Python.xcframework/ios-*/Python.framework
 iOS/testbed/iOSTestbed.xcodeproj/project.xcworkspace
 iOS/testbed/iOSTestbed.xcodeproj/xcuserdata
 iOS/testbed/iOSTestbed.xcodeproj/xcshareddata
-visionOS/testbed/Python.xcframework/xr*-*/bin
-visionOS/testbed/Python.xcframework/xr*-*/include
-visionOS/testbed/Python.xcframework/xr*-*/lib
-visionOS/testbed/Python.xcframework/xr*-*/Python.framework
+visionOS/testbed/Python.xcframework/xros-*/bin
+visionOS/testbed/Python.xcframework/xros-*/include
+visionOS/testbed/Python.xcframework/xros-*/lib
+visionOS/testbed/Python.xcframework/xros-*/Python.framework
 visionOS/testbed/visionOSTestbed.xcodeproj/project.xcworkspace
 visionOS/testbed/visionOSTestbed.xcodeproj/xcuserdata
 visionOS/testbed/visionOSTestbed.xcodeproj/xcshareddata

--- a/visionOS/testbed/Python.xcframework/xros-arm64-simulator/README
+++ b/visionOS/testbed/Python.xcframework/xros-arm64-simulator/README
@@ -1,0 +1,4 @@
+This directory is intentionally empty.
+
+It should be used as a target for `--enable-framework` when compiling an visionOS simulator
+build for testing purposes (either x86_64 or ARM64).

--- a/visionOS/testbed/Python.xcframework/xros-arm64/README
+++ b/visionOS/testbed/Python.xcframework/xros-arm64/README
@@ -1,0 +1,4 @@
+This directory is intentionally empty.
+
+It should be used as a target for `--enable-framework` when compiling an visionOS on-device
+build for testing purposes.


### PR DESCRIPTION
Apologies for the large amount of PRs recently, but this corrects *another* oversight in visionOS patch -- it adds the folders w/ READMEs for the slices of the XCFramework. The .gitignore is also simplified --- apologies for the typo in the commit msg.